### PR TITLE
fix(check): catch asyncio.TimeoutError and return per-snippet errors

### DIFF
--- a/server/manager.py
+++ b/server/manager.py
@@ -228,7 +228,7 @@ class Manager:
                     timeout=timeout,
                     is_header=True,
                 )
-            except TimeoutError as e:
+            except (asyncio.TimeoutError, TimeoutError) as e:
                 logger.error("Header command timed out")
                 raise e
             except Exception as e:

--- a/server/repl.py
+++ b/server/repl.py
@@ -280,7 +280,7 @@ class Repl:
                 self.send(snippet, is_header=is_header, infotree=infotree),
                 timeout=timeout,
             )
-        except TimeoutError as e:
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error(
                 "\\[{}] Lean REPL command timed out in {} seconds, killing process immediately",
                 self.uuid.hex[:8],
@@ -288,7 +288,7 @@ class Repl:
             )
             # Kill the process immediately to prevent hang
             await self.kill_immediately()
-            raise e
+            raise
         except LeanError as e:
             logger.exception("Lean REPL error: %s", e)
             raise e
@@ -478,7 +478,7 @@ class Repl:
                 )
                 logger.debug(f"[{self.uuid.hex[:8]}] Health check passed")
                 return True
-            except TimeoutError:
+            except (asyncio.TimeoutError, TimeoutError):
                 logger.warning(
                     f"[{self.uuid.hex[:8]}] Health check failed: command timed out after {timeout}s"
                 )


### PR DESCRIPTION
- Handle asyncio.TimeoutError (Py3.10) in REPL send_timeout/health_check and manager header prep
- Keep /check batch responses stable by returning ReplResponse(error=...) instead of raising HTTPException
- Wrap prisma proof persistence to avoid failing requests on DB errors
- Add regression test ensuring send_timeout kills on asyncio timeout